### PR TITLE
Fix typo on the index page ("about" -> "above")

### DIFF
--- a/data/index.md
+++ b/data/index.md
@@ -8,7 +8,7 @@ up-to-date.
 
 ![Example OCurrent pipeline](/pipeline.svg)
 
-For example, the pipeline shown about fetches the head of a GitHub repository's
+For example, the pipeline shown above fetches the head of a GitHub repository's
 `master` branch, builds it, runs the tests, and deploys the binary if the tests
 pass. When a new commit is pushed, it runs the pipeline again.
 


### PR DESCRIPTION
/CC @smolck.