### PR TITLE
Fixup changed github urls to example code.

### DIFF
--- a/data/examples/01_docker_build_local.md
+++ b/data/examples/01_docker_build_local.md
@@ -57,6 +57,6 @@ yellow means queued or waiting for permission to start, and red means failed.
 Clicking on a box shows the log for that operation (though not all operations
 have logs; `head commit` doesn't, for example).
 
-[docker_build_local.ml]: https://github.com/talex5/ocurrent/blob/master/examples/docker_build_local.ml
-[plugins]: https://github.com/talex5/ocurrent/blob/master/plugins
+[docker_build_local.ml]: https://github.com/ocurrent/ocurrent/blob/master/doc/examples/docker_build_local.ml
+[plugins]: https://github.com/ocurrent/ocurrent/blob/master/plugins
 [graphviz]: https://graphviz.org/

--- a/data/examples/02_build_matrix.md
+++ b/data/examples/02_build_matrix.md
@@ -40,4 +40,4 @@ versions of the compiler and the Dockerfile just selects one of them).
 
 The generated images are then tagged with the compiler version used to build them.
 
-[build_matrix.ml]: https://github.com/talex5/ocurrent/blob/master/examples/build_matrix.ml
+[build_matrix.ml]: https://github.com/ocurrent/ocurrent/blob/master/doc/examples/build_matrix.ml


### PR DESCRIPTION
Linked to mdx porting https://github.com/ocurrent/ocurrent/pull/278