### PR TITLE
Updated site base URL

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 
-baseURL: "https://ocurrent.github.io/"
+baseURL: "https://www.ocurrent.org/"
 languageCode: "en-us"
 title: "OCurrent"
 MetaDataFormat: "yaml"
@@ -28,7 +28,7 @@ menu:
         - identifier: "api"
           name: "API"
           title: "api"
-          url: "https://ocurrent.github.io/ocurrent/"
+          url: "/ocurrent"
           weight: 4
         - identifer: "community"
           name: "Community"


### PR DESCRIPTION
Changed from ocurrent.github.io to ocurrent.org