### PR TITLE
Add import management system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
 RUN git config --global user.email "contact@tarides.com"
 RUN git config --global user.name "Tarides Pipeline"
 EXPOSE 8080
-ENTRYPOINT [ "dumb-init", "website-watcher" ]
+ENTRYPOINT [ "dumb-init", "website-watcher", "run" ]

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ dune exec -- bin/main.exe --github-account-allowlist="<USER>" \
                           --github-app-id="<ID>" \
                           --github-private-key-file="key.pem" \
                           --github-webhook-secret-file="secret-file" \
-                          --repo="ocurrent/ocurrent.org" \
                           --branch="master" \
                           -v
 ```

--- a/bin/conf.ml
+++ b/bin/conf.ml
@@ -122,7 +122,7 @@ module Yaml = struct
     let title = Y.access_str ~field:"title" yaml in
     let description = Y.access_str ~field:"description" yaml in
     let dst = Fpath.v (Y.access_str ~field:"dst" yaml) in
-    File.Index.v ~title ~description ~dst ()
+    File.Index.v ~title ~description ~dst
 
   let output_of_yaml yaml =
     let yaml = Y.access ~field:"output" yaml in

--- a/bin/conf.mli
+++ b/bin/conf.mli
@@ -5,8 +5,10 @@ val output : t -> Current_github.Repo_id.t * string
 (** [output t] gives the repository and the branch associated to the output
     repository where the website will be built. *)
 
-val repos : t -> (Current_github.Repo_id.t * File.Copy.info list) list
-(** [repos t] returns, for each repository, the files tracked into this
+val repos :
+  t ->
+  (Current_github.Repo_id.t * File.Copy.info list * File.Data.info list) list
+(** [repos t] returns, for each repository, the files and data tracked into this
     repository. This files are going to be copied into the base skeleton. For
     more information about the vocabulary, see {!Pipeline}. *)
 
@@ -30,3 +32,8 @@ module Static : sig
   val remote_name : string
   (** The name of the remote to add to git. *)
 end
+
+val lint : ?test:bool -> Fpath.t -> (unit, [ `Msg of string ]) result
+(** [lint file] ensures the file given in argument work as expected, i.e it's
+    able to be parse as a tracker file. [test] executes more checks and is
+    intended to be used for tests. *)

--- a/bin/content.mli
+++ b/bin/content.mli
@@ -3,5 +3,19 @@ val fetch :
   commit:Current_git.Commit.t Current.t ->
   File.Copy.info list ->
   File.Copy.t list Current.t
-(** [fetch ~repo ~commit files] extracts files with their content as a list of
-    {!File.t} from a repository [repo], pinned at a certain [commit]. *)
+(** [fetch ~repo ~commit files] extracts files from a repository [repo], pinned
+    at a certain [commit]. They are returned with their content as a list of
+    {!File.Copy.t}. *)
+
+val store :
+  repo:string ->
+  commit:Current_git.Commit.t Current.t ->
+  File.Data.info list ->
+  File.Data.t list Current.t
+(** [store ~repo ~commit data] stores the data from a repository [repo], pinned
+    at a certain [commit] in a temporary place. It returns their temporary
+    location as a list of {!File.Data.t}. *)
+
+val with_close_store : (unit -> 'a Lwt.t) -> 'a Lwt.t
+(** [with_close_store fn] ensures the store is freed after the function [fn]
+    runs. *)

--- a/bin/file.ml
+++ b/bin/file.ml
@@ -102,3 +102,67 @@ module Index = struct
     in
     Writer.raw_write ~path page
 end
+
+module Data = struct
+  open Lwt.Syntax
+
+  type info = { src : Fpath.t; dst : Fpath.t }
+  type t = { metadata : info; store_at : Fpath.t }
+
+  let source store = store.metadata.src |> Fpath.to_string
+  let destination store = store.metadata.dst |> Fpath.to_string
+
+  let info_of_json : Yojson.Safe.t -> info = function
+    | `Assoc [ ("src", `String src); ("dst", `String dst) ] ->
+        let src = Fpath.v src in
+        let dst = Fpath.v dst in
+        { src; dst }
+    | _ -> invalid_arg "Unable to parse the JSON for Data.info."
+
+  let of_json = function
+    | `Assoc
+        [
+          ("src", `String src);
+          ("dst", `String dst);
+          ("store_at", `String store_at);
+        ] ->
+        let src = Fpath.v src in
+        let dst = Fpath.v dst in
+        let store_at = Fpath.v store_at in
+        { metadata = { src; dst }; store_at }
+    | _ -> invalid_arg "Unable to parse the JSON for Data.t."
+
+  let info_to_json t : Yojson.Safe.t =
+    `Assoc
+      [
+        ("src", `String (Fpath.to_string t.src));
+        ("dst", `String (Fpath.to_string t.dst));
+      ]
+
+  let to_json t =
+    `Assoc
+      [
+        ("src", `String (Fpath.to_string t.metadata.src));
+        ("dst", `String (Fpath.to_string t.metadata.dst));
+        ("store_at", `String (Fpath.to_string t.store_at));
+      ]
+
+  let v ~src ~dst =
+    let src = Fpath.normalize src in
+    let dst = Fpath.normalize dst in
+    { src; dst }
+
+  let compare t1 t2 = Fpath.compare t1.store_at t2.store_at
+
+  let store info ~tmp_dir ~dir =
+    let name = Fpath.(normalize info.src |> basename) in
+    let store_at = Fpath.add_seg tmp_dir name in
+    let store = { metadata = info; store_at } in
+    let src = Fpath.(append dir info.src) in
+    let+ () = Utils.Cmd.move src store_at in
+    store
+
+  let export store ~dir =
+    let dst = Fpath.(append dir store.metadata.dst) in
+    Utils.Cmd.move store.store_at dst
+end

--- a/bin/file.mli
+++ b/bin/file.mli
@@ -28,3 +28,19 @@ module Index : sig
   val v : title:string -> description:string -> dst:Fpath.t -> t
   val write : t -> dir:Fpath.t -> unit Lwt.t
 end
+
+module Data : sig
+  type info
+  type t
+
+  val source : t -> string
+  val destination : t -> string
+  val info_to_json : info -> Yojson.Safe.t
+  val info_of_json : Yojson.Safe.t -> info
+  val to_json : t -> Yojson.Safe.t
+  val of_json : Yojson.Safe.t -> t
+  val v : src:Fpath.t -> dst:Fpath.t -> info
+  val compare : t -> t -> int
+  val store : info -> tmp_dir:Fpath.t -> dir:Fpath.t -> t Lwt.t
+  val export : t -> dir:Fpath.t -> unit Lwt.t
+end

--- a/bin/file.mli
+++ b/bin/file.mli
@@ -25,6 +25,6 @@ module Index : sig
   val destination : t -> Fpath.t
   val of_json : Yojson.Safe.t -> t
   val to_json : t -> Yojson.Safe.t
-  val v : title:string -> description:string -> dst:Fpath.t -> unit -> t
+  val v : title:string -> description:string -> dst:Fpath.t -> t
   val write : t -> dir:Fpath.t -> unit Lwt.t
 end

--- a/bin/git.ml
+++ b/bin/git.ml
@@ -27,11 +27,11 @@ let remote ?cwd ~job = function
       git ?cwd ~job args
 
 let add_all ?cwd ~job () =
-  let args = [ "add"; "--all" ] in
+  let args = [ "add"; "." ] in
   git ?cwd ~job args
 
 let rm_all ?cwd ~job () =
-  let args = [ "rm"; "--ignore-unmatch"; "'*'" ] in
+  let args = [ "rm"; "-rf"; "*" ] in
   git ?cwd ~job args
 
 let commit ?cwd ~job ?(allow_empty = false) msg =

--- a/bin/hugo.mli
+++ b/bin/hugo.mli
@@ -3,7 +3,9 @@ val build :
   conf:Conf.t ->
   File.Copy.t list Current.t ->
   File.Index.t list ->
+  File.Data.t list Current.t ->
   unit Current.t
-(** [build ~commit files indexes] builds the `hugo` website using the [files]
-    that need to be copied and the [indexes] that must be create. The build wil
-    be done in the repository point by [commit]. *)
+(** [build ~commit files indexes data] builds the `hugo` website using the
+    [files] that need to be copied, the [indexes] that must be created and, the
+    [data] that needs to be exported. The build will be done in the repository
+    point by [commit]. *)

--- a/bin/utils.ml
+++ b/bin/utils.ml
@@ -8,6 +8,81 @@ module Cmd = struct
     let dst = Fpath.to_string dst in
     let args = [ "-ra"; src; dst ] in
     copy ?cwd ~job args
+
+  let mv args =
+    let open Lwt.Syntax in
+    let args = "mv" :: args in
+    let* status = Lwt_process.exec ("mv", Array.of_list args) in
+    Unix.(
+      match status with
+      | WEXITED 0 -> Lwt.return_unit
+      | WEXITED n ->
+          let msg = Printf.sprintf "mv: exited with a non zero status (%d)" n in
+          Lwt.fail_with msg
+      | WSTOPPED n ->
+          let msg = Printf.sprintf "mv: stopped with status (%d)" n in
+          Lwt.fail_with msg
+      | WSIGNALED n ->
+          let msg = Printf.sprintf "mv: signaled with status (%d)" n in
+          Lwt.fail_with msg)
+
+  let move src dst =
+    let src = Fpath.to_string src in
+    let dst = Fpath.to_string dst in
+    let args = [ src; dst ] in
+    mv args
+end
+
+module Dir = struct
+  open Lwt.Infix
+
+  (* This function comes from the {!Current.Process} module *)
+  let rm_f_tree root =
+    let rec rmtree path =
+      Lwt_unix.lstat path >>= fun info ->
+      match info.Unix.st_kind with
+      | Unix.S_REG | Unix.S_LNK | Unix.S_BLK | Unix.S_CHR | Unix.S_SOCK
+      | Unix.S_FIFO ->
+          Lwt_unix.unlink path
+      | Unix.S_DIR ->
+          Lwt_unix.chmod path 0o700 >>= fun () ->
+          Lwt_unix.files_of_directory path
+          |> Lwt_stream.iter_s (function
+               | "." | ".." -> Lwt.return_unit
+               | leaf -> rmtree (Filename.concat path leaf))
+          >>= fun () -> Lwt_unix.rmdir path
+    in
+    rmtree root
+
+  let check_dir x =
+    Lwt.catch
+      (fun () ->
+        Lwt_unix.stat x >|= function
+        | Unix.{ st_kind = S_DIR; _ } -> `Present
+        | _ -> Fmt.failwith "Exists, but is not a directory: %S" x)
+      (function
+        | Unix.Unix_error (Unix.ENOENT, _, _) -> Lwt.return `Missing
+        | exn -> Lwt.fail exn)
+
+  let ensure path =
+    let path = Fpath.to_string path in
+    check_dir path >>= function
+    | `Present ->
+        Logs.debug (fun f -> f "Directory %s exists" path);
+        Lwt.return_unit
+    | `Missing ->
+        Logs.info (fun f -> f "Creating %s directory" path);
+        Lwt_unix.mkdir path 0o777
+
+  let delete path =
+    let path = Fpath.to_string path in
+    check_dir path >>= function
+    | `Present ->
+        Logs.info (fun f -> f "Delete directory %s" path);
+        rm_f_tree path
+    | `Missing ->
+        Logs.debug (fun f -> f "Skip deletion for %s directory" path);
+        Lwt.return_unit
 end
 
 module Yaml = struct
@@ -56,7 +131,8 @@ module Yaml = struct
   let access_str ~field yaml = access ~field yaml |> from_string
 
   let access_array ~field f yaml =
-    access ~field yaml |> from_array |> List.map f
+    try access ~field yaml |> from_array |> List.map f
+    with Invalid_argument _ -> []
 
   let access_str_array ~field yaml = access_array ~field from_string yaml
 end

--- a/bin/utils.mli
+++ b/bin/utils.mli
@@ -11,6 +11,19 @@ module Cmd : sig
   (** [copy_all ~cwd ~job src dst] executes a [cp -a src/* dst/] from [cwd].
       [job] is a reference to an {!Current.t} job with whom the action is linked
       to. *)
+
+  val move : Fpath.t -> Fpath.t -> unit Lwt.t
+  (** [move src dst] executes a [mv src dst/] from [cwd]. *)
+end
+
+module Dir : sig
+  (** This module gives helpers to manipulate directory. *)
+
+  val ensure : Fpath.t -> unit Lwt.t
+  (** [ensure dir] creates a new directory if it doesn't already exist. *)
+
+  val delete : Fpath.t -> unit Lwt.t
+  (** [delete dir] deletes the directory if it already exist. *)
 end
 
 module Yaml : sig
@@ -53,7 +66,8 @@ module Yaml : sig
       ]}
 
       where [access_array ~field:"book" ~f yaml] will return an object in the
-      format required by the [f] function. *)
+      format required by the [f] function. It returns an empty list in case the
+      field can't be found. *)
 
   val access_str_array : field:string -> Yaml.value -> string list
   (** [access_str_array ~field yaml] is the same as {!access_array} but with a


### PR DESCRIPTION
Fixes #15

This PR brings support to copy. Internally, it relies on a temporary repository in `var` to ensure we keep the data in the right place.