### PR TITLE
Add licenses to the project.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,76 @@
+Licenses
+========
+
+- Content is released under CC BY-SA 4.0.
+- Code that implements the various tools in this repository is released under the ISC license.
+- Code examples within content are released under the UNLICENSE.
+- Design of the site. All rights reserved by the OCurrent project.
+- OCaml logo is released under the UNLICENSE.
+- Abstracts, slides from meetings, blog posts. Rights retained by contributor.
+
+* CC BY-SA 4.0
+
+A short summary can be found at https://creativecommons.org/licenses/by-sa/4.0/
+The full license is available at https://creativecommons.org/licenses/by-sa/4.0/legalcode
+
+You are free to:
+
+_Share_ — copy and redistribute the material in any medium or format
+_Adapt_ — remix, transform, and build upon the material
+  for any purpose, even commercially.
+
+The licensor cannot revoke these freedoms as long as you follow the
+license terms.
+
+Under the following terms:
+
+_Attribution_ — You must give _appropriate credit_, provide a link to
+the license, and _indicate if changes were made_. You may do so in any
+reasonable manner, but not in any way that suggests the licensor
+endorses you or your use.
+
+_ShareAlike_ — If you remix, transform, or build upon the material, you
+must distribute your contributions under the _same license_ as the
+original.
+
+_No additional restrictions_ — You may not apply legal terms or
+technological measures that legally restrict others from doing
+anything the license permits.
+
+
+* UNLICENSE
+
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org/>
+
+* ISC
+
+ISC License (ISC)
+Copyright (c) 2022, OCurrent project
+Copyright (c) 2022, Etienne Marais <etienne@maiste.fr>
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/static/LICENSE
+++ b/static/LICENSE
@@ -1,0 +1,66 @@
+Licenses
+========
+
+- Content is released under CC BY-SA 4.0.
+- Code examples within content are released under the UNLICENSE.
+- Design of the site. All rights reserved by the OCurrent project.
+- OCaml logo is released under the UNLICENSE.
+- Abstracts, slides from meetings, blog posts. Rights retained by contributor.
+
+* CC BY-SA 4.0
+
+A short summary can be found at https://creativecommons.org/licenses/by-sa/4.0/
+The full license is available at https://creativecommons.org/licenses/by-sa/4.0/legalcode
+
+You are free to:
+
+_Share_ — copy and redistribute the material in any medium or format
+_Adapt_ — remix, transform, and build upon the material
+  for any purpose, even commercially.
+
+The licensor cannot revoke these freedoms as long as you follow the
+license terms.
+
+Under the following terms:
+
+_Attribution_ — You must give _appropriate credit_, provide a link to
+the license, and _indicate if changes were made_. You may do so in any
+reasonable manner, but not in any way that suggests the licensor
+endorses you or your use.
+
+_ShareAlike_ — If you remix, transform, or build upon the material, you
+must distribute your contributions under the _same license_ as the
+original.
+
+_No additional restrictions_ — You may not apply legal terms or
+technological measures that legally restrict others from doing
+anything the license permits.
+
+
+* UNLICENSE
+
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org/>
+


### PR DESCRIPTION
The first license refers to the projects themselves, whereas the second license will be exported into [ocurrent/ocurrent.github.io](https://github.com/ocurrent/ocurrent.github.io). 

They are a copy of the [ocaml.org](https://github.com/ocaml/ocaml.org) to keep homogeneity in the Tarides ecosystem.