### PR TITLE
Support Slack notification.

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -3,10 +3,11 @@
  (package ocurrentorg)
  (name main)
  (libraries
+  current_docker
   current_git
   current_github
+  current_slack
   current_web
-  current_docker
   cmdliner
   fmt.cli
   logs.cli

--- a/bin/pipeline.ml
+++ b/bin/pipeline.ml
@@ -99,3 +99,18 @@ let v ~branch ~app () =
              memorize selections |> Current.list_seq |> Current.map List.flatten
            in
            Hugo.build ~commit ~conf files indexes data
+
+let notify_status ?channel x =
+  match channel with
+  | None -> x
+  | Some channel ->
+      let s =
+        let+ state = Current.catch x in
+        Fmt.str "ocurrent.org-watcher: %a"
+          (Current_term.Output.pp Current.Unit.pp)
+          state
+      in
+      Current.all
+        [ Current_slack.post channel ~key:"ocurrent.org-watcher-status" s; x ]
+
+let v ?channel ~branch ~app () = v ~branch ~app () |> notify_status ?channel

--- a/bin/pipeline.mli
+++ b/bin/pipeline.mli
@@ -1,4 +1,10 @@
-val v : branch:string -> app:Current_github.App.t -> unit -> unit Current.t
-(** [v ~branch ~app ()] create a pipeline to give to a {!Current.Engine}. The
-    config is extracted from the [app] on [branch]. [app] is the credential for
-    the GitHub App that monitors the repository. *)
+val v :
+  ?channel:Current_slack.channel ->
+  branch:string ->
+  app:Current_github.App.t ->
+  unit ->
+  unit Current.t
+(** [v ?channel ~branch ~app ()] create a pipeline to give to a
+    {!Current.Engine}. The config is extracted from the [app] on [branch]. [app]
+    is the credential for the GitHub App that monitors the repository. If
+    [channel] is provided, it will push the status for each build on slack. *)

--- a/dune-project
+++ b/dune-project
@@ -18,6 +18,7 @@
     (current_git (>= 0.6.4))
     (current_github (>= 0.6.4))
     (current_docker (>= 0.6.4))
+    (current_slack (>= 0.6.4))
     (current_web (>= 0.6.4))
     (yaml (>= 3.1.0))
     (bos (>= 0.2.1))

--- a/ocurrentorg.opam
+++ b/ocurrentorg.opam
@@ -14,6 +14,7 @@ depends: [
   "current_git" {>= "0.6.4"}
   "current_github" {>= "0.6.4"}
   "current_docker" {>= "0.6.4"}
+  "current_slack" {>= "0.6.4"}
   "current_web" {>= "0.6.4"}
   "yaml" {>= "3.1.0"}
   "bos" {>= "0.2.1"}

--- a/stack.yml
+++ b/stack.yml
@@ -3,7 +3,13 @@ version: '3.9'
 services:
   ocurrentorg-watcher:
     image: ocurrent/watcher:latest
-    command: --github-account-allowlist="maiste" --github-app-id="232762"  --github-private-key-file="/run/secrets/ocurrentorg-key" --github-webhook-secret-file="/run/secrets/ocurrentorg-secret" --branch=live-engine -v
+    command: >
+      --github-account-allowlist="maiste"
+      --github-app-id="232762"
+      --github-private-key-file="/run/secrets/ocurrentorg-key"
+      --github-webhook-secret-file="/run/secrets/ocurrentorg-secret"
+      --branch=live-engine -v
+      --slack="/run/secret/ocurrentorg-slack"
     ports:
       - "8090:8080"
     secrets:

--- a/stack.yml
+++ b/stack.yml
@@ -15,6 +15,7 @@ services:
     secrets:
       - "ocurrentorg-key"
       - "ocurrentorg-secret"
+      - "ocurrentorg-slack"
       - source: "ocurrentorg-ssh"
         mode: 0600
 
@@ -22,6 +23,8 @@ secrets:
   ocurrentorg-key:
     external: true
   ocurrentorg-secret:
+    external: true
+  ocurrentorg-slack:
     external: true
   ocurrentorg-ssh:
     external: true


### PR DESCRIPTION
This PR makes the ocurrent.org watcher push updates to the `firehose` channel. @tmcgilchrist, as there isn't any strong example apart from the `docker-base-images` could I have your confirmation that this is the right way to do it? 